### PR TITLE
Remove local/ suffix from docker tag name

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -72,7 +72,7 @@ var runCmd = &cobra.Command{
 			defer close(shutdown)
 
 			buildingPhase := log.StartPhase("[building]", "workspace image")
-			ref := filepath.Join("local/workspace-image:latest")
+			ref := filepath.Join("workspace-image:latest")
 			bldLog := log.Writer()
 			err = runtime.BuildImage(bldLog, ref, cfg)
 			if err != nil {


### PR DESCRIPTION
## Description

local/ suffix fails on Windows with invalid argument "local\\workspace-image:latest" for "-t, --tag" flag: invalid reference format

## Related Issue(s)
Fixes #22

## How to test

Follow [Getting started](https://github.com/gitpod-io/run-gp#getting-started) from the README on a Windows 11 machine

## Release Notes
```release-note
* Fix building docker image for Windows 11
```

## Documentation
