### PR TITLE
Fix the command name displayed on "--help"

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,7 @@ import (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "rungp",
+	Use:   "run-gp",
 	Short: "start a local dev-environment using a .gitpdod.yaml file",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		cfg, err := config.ReadInConfig()


### PR DESCRIPTION
## Description

Currently when we use "--help", this is what's displayed:

<img width="951" alt="image" src="https://user-images.githubusercontent.com/418083/181904516-d3daf464-8f98-4e38-91d5-5dbf22be5130.png">

This PR replaces 'rungp' by 'run-gp'.