### PR TITLE
Messy but effective option to just build the image.

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -86,6 +86,9 @@ var runCmd = &cobra.Command{
 			}
 			bldLog.Discard()
 			buildingPhase.Success()
+			if runOpts.StartOpts.NoStart {
+			    return;
+			}
 
 			var (
 				publicSSHKey   string
@@ -149,6 +152,7 @@ var runOpts struct {
 func init() {
 	rootCmd.AddCommand(runCmd)
 	runCmd.Flags().BoolVar(&runOpts.StartOpts.NoPortForwarding, "no-port-forwarding", false, "disable port-forwarding for ports in the .gitpod.yml")
+	runCmd.Flags().BoolVar(&runOpts.StartOpts.NoStart, "do-not-start", false, "create the image only, do not start.")
 	runCmd.Flags().IntVar(&runOpts.StartOpts.PortOffset, "port-offset", 0, "shift exposed ports by this number")
 	runCmd.Flags().IntVar(&runOpts.StartOpts.IDEPort, "ide-port", 8080, "port to expose open vs code server")
 	runCmd.Flags().IntVar(&runOpts.StartOpts.SSHPort, "ssh-port", 8082, "port to expose SSH on (set to 0 to disable SSH)")

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -71,6 +71,7 @@ type Builder interface {
 type StartOpts struct {
 	PortOffset       int
 	NoPortForwarding bool
+	NoStart          bool
 	IDEPort          int
 	SSHPort          int
 	SSHPublicKey     string


### PR DESCRIPTION
## Description
Added CLI option to not start the image once built.

## Related Issue(s)
use the tool to allow automated creation of docker images which can then be transfered into an airgapped environment.

Fixes #

## How to test
use the badge to start run-gp in gitpod
./run-gp run --do-not-run
docker images
see that the image was created but that you are still in your original gitpod environment. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```CLI Option `--do-not-start` created to stop after image creation
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* No
