### PR TITLE
Fix #40

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -124,6 +124,7 @@ var runCmd = &cobra.Command{
 			opts.SSHPublicKey = publicSSHKey
 			err := runtime.StartWorkspace(ctx, ref, cfg, opts)
 			if err != nil {
+				log.Warnf("unable to Start Workspace: %+v", err)
 				return
 			}
 			runLogs.Discard()

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -7,7 +7,6 @@ package cmd
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -100,7 +99,7 @@ var runCmd = &cobra.Command{
 				publicSSHKeyFN = filepath.Join(home, strings.TrimPrefix(publicSSHKeyFN, "~"))
 			}
 
-			if fc, err := ioutil.ReadFile(publicSSHKeyFN); err == nil {
+			if fc, err := os.ReadFile(publicSSHKeyFN); err == nil {
 				publicSSHKey = string(fc)
 			} else if rootOpts.Verbose {
 				log.Warnf("cannot read public SSH key from %s: %v", publicSSHKeyFN, err)

--- a/pkg/runtime/docker.go
+++ b/pkg/runtime/docker.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -78,7 +77,7 @@ func (dr docker) BuildImage(ctx context.Context, logs io.WriteCloser, ref string
 		if err != nil {
 			return err
 		}
-		fc, err = ioutil.ReadFile(filepath.Join(dr.Workdir, obj.Context, obj.File))
+		fc, err = os.ReadFile(filepath.Join(dr.Workdir, obj.Context, obj.File))
 		if err != nil {
 			// TODO(cw): make error actionable
 			return err
@@ -102,7 +101,7 @@ func (dr docker) BuildImage(ctx context.Context, logs io.WriteCloser, ref string
 
 	fmt.Fprintf(logs, "\nDockerfile:%s\n", df)
 
-	err = ioutil.WriteFile(filepath.Join(tmpdir, "Dockerfile"), []byte(df), 0644)
+	err = os.WriteFile(filepath.Join(tmpdir, "Dockerfile"), []byte(df), 0644)
 	if err != nil {
 		return err
 	}
@@ -195,7 +194,7 @@ func (dr docker) StartWorkspace(ctx context.Context, workspaceImage string, cfg 
 		"THEIA_SUPERVISOR_TOKENS":        `{"token": "invalid","kind": "gitpod","host": "gitpod.local","scope": [],"expiryDate": ` + time.Now().Format(time.RFC3339) + `,"reuse": 2}`,
 		"VSX_REGISTRY_URL":               "https://https://open-vsx.org/",
 	}
-	tmpf, err := ioutil.TempFile("", "rungp-*.env")
+	tmpf, err := os.CreateTemp("", "rungp-*.env")
 	if err != nil {
 		return err
 	}
@@ -207,7 +206,7 @@ func (dr docker) StartWorkspace(ctx context.Context, workspaceImage string, cfg 
 	defer os.Remove(tmpf.Name())
 
 	if opts.SSHPublicKey != "" {
-		tmpf, err := ioutil.TempFile("", "rungp-*.pub")
+		tmpf, err := os.CreateTemp("", "rungp-*.pub")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description

This keeps track of the allocated host ports in the `docker run` command and reports conflicts with (as best it can) where they came from. Related to that, in actually checks that the `port:` value in `.gitpod.yml` is in fact an `int` rather than just assuming it so. Finally, it also stops swallowing err from the actual Start Workspace invocation

## Related Issue(s)

Fixes #40

## How to test

* checkout `main`
* build
* run with the cited example repo's `.gitpod.yml`
* observe the failure to launch
* checkout this branch
* repeat that exercise and observe there is now a helpful message showing the conflict

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
